### PR TITLE
Build with the limited ABI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+py-limited-api=cp32

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ module_SF2Synth = Extension(
 	'pyTinySoundFont.PySF2Synth',
 	sources = SF2Synth_Src,
 	include_dirs = SF2Synth_IncludeDirs,
+	py_limited_api = True,
+	define_macros=[('Py_LIMITED_API', '0x03020000')],
 	extra_compile_args=extra_compile_args)
 
 setup(


### PR DESCRIPTION
Thank you for this project!
I hope you don't mind that I built wheels for pyTinySoundFont and uploaded them to PyPI, so that it is easier to use this project by installing via `pip`: https://pypi.org/project/pyTinySoundFont/
Of course, I can add you as a owner if you provide me with your username, since this is your project after all.

Anyway, in order to create wheels that are compatible with multiple Python versions, I used the changes in this PR to indicate that it uses the "limited ABI". This brings this repository in line with what is uploaded to PyPI.